### PR TITLE
Infinite terrain generation

### DIFF
--- a/client/nethandler.lua
+++ b/client/nethandler.lua
@@ -73,7 +73,7 @@ end
 
 function nethandler.chunkremove(g, d)
   local cx, cy, cz = tonumber(d.cx), tonumber(d.cy), tonumber(d.cz)
-  g.world:removechunk(cx, cy, cz):destroy()
+  g.world:removechunk(loex.hash.spatial(cx, cy, cz)):destroy()
 end
 
 return nethandler

--- a/client/nethandler.lua
+++ b/client/nethandler.lua
@@ -52,8 +52,7 @@ function nethandler.entityadd(g, d)
 end
 
 function nethandler.entityremove(g, d)
-  local entity = g.world:entity(d.id)
-  entity.dead = true
+  g.world:remove(d.id)
 end
 
 function nethandler.entityremoteset(g, d)

--- a/client/nethandler.lua
+++ b/client/nethandler.lua
@@ -63,11 +63,16 @@ function nethandler.entityremoteset(g, d)
 end
 
 function nethandler.chunkadd(g, d)
-  assert(d.bin:getSize() == loex.chunk.size ^ 3, "Chunk data of wrong size!")
-
+  local expectedsize = loex.chunk.size ^ 3
   local cx, cy, cz = tonumber(d.cx), tonumber(d.cy), tonumber(d.cz)
   local c = loex.chunk.new(cx, cy, cz)
-  c:init(d.bin)
+  if d.bin then
+    assert(
+      d.bin:getSize() == expectedsize,
+      ("Chunk data of wrong size! Expected %d bytes, got %d bytes"):format(expectedsize, d.bin:getSize())
+    )
+    c:init(d.bin)
+  end
   g.world:insertchunk(c)
 end
 

--- a/client/nethandler.lua
+++ b/client/nethandler.lua
@@ -51,9 +51,7 @@ function nethandler.entityadd(g, d)
   g.world:insert(entity)
 end
 
-function nethandler.entityremove(g, d)
-  g.world:remove(d.id)
-end
+function nethandler.entityremove(g, d) g.world:remove(d.id) end
 
 function nethandler.entityremoteset(g, d)
   local entity = g.world:entity(d.id)

--- a/client/nethandler.lua
+++ b/client/nethandler.lua
@@ -36,7 +36,7 @@ end
 function nethandler.entitymove(g, d)
   assert(false)
   local x, y, z = tonumber(d.x), tonumber(d.y), tonumber(d.z)
-  local entity = g.world:get(d.id)
+  local entity = g.world:entity(d.id)
   assert(entity)
   entity.x = x
   entity.y = y
@@ -52,12 +52,12 @@ function nethandler.entityadd(g, d)
 end
 
 function nethandler.entityremove(g, d)
-  local entity = g.world:get(d.id)
+  local entity = g.world:entity(d.id)
   entity.dead = true
 end
 
 function nethandler.entityremoteset(g, d)
-  local entity = g.world:get(d.id)
+  local entity = g.world:entity(d.id)
   if entity.id == g.player.id and d.property:match("[xyz]") then return end -- TODO: position correction
   entity[d.property] = d.value
 end
@@ -68,7 +68,7 @@ function nethandler.chunkadd(g, d)
   local cx, cy, cz = tonumber(d.cx), tonumber(d.cy), tonumber(d.cz)
   local c = loex.chunk.new(cx, cy, cz)
   c:init(d.bin)
-  g.world:chunk(cx, cy, cz, c)
+  g.world:insertchunk(c)
 end
 
 function nethandler.chunkremove(g, d)

--- a/client/scenes/gameworld.lua
+++ b/client/scenes/gameworld.lua
@@ -73,9 +73,9 @@ function gameworld:init(player)
   self.master = master
   local world = loex.world.new()
   world.ontilemodified:catch(self.ontilemodified, self)
-  world.onentityadded:catch(self.onentityadded, self)
+  world.onentityinserted:catch(self.onentityinserted, self)
   world.onentityremoved:catch(self.onentityremoved, self)
-  world.onchunkadded:catch(self.onchunkadded, self)
+  world.onchunkinserted:catch(self.onchunkinserted, self)
   world.onchunkremoved:catch(self.onchunkremoved, self)
 
   self.world = world
@@ -95,14 +95,13 @@ function gameworld:init(player)
   lg.setMeshCullMode("back")
 end
 
-function gameworld:onchunkadded(chunk)
+function gameworld:onchunkinserted(chunk)
   local x, y, z = chunk.x, chunk.y, chunk.z
   self:requestremesh(chunk)
 end
 
 function gameworld:onchunkremoved(chunk) end
-
-function gameworld:onentityadded(entity) print(entity.id .. " added") end
+function gameworld:onentityinserted(entity) print(entity.id .. " added") end
 
 function gameworld:onentityremoved(entity) print(entity.id .. " removed") end
 
@@ -139,7 +138,7 @@ function gameworld:update(dt)
   while self.remeshchannel:peek() do
     local data = self.remeshchannel:pop()
     if not data then break end
-    local c = self.world:chunk(data.cx, data.cy, data.cz)
+    local c = self.world:chunk(loex.hash.spatial(data.cx, data.cy, data.cz))
     if c.model then c.model.mesh:release() end
     c.model = nil
     c.inremesh = false
@@ -311,19 +310,20 @@ end
 function gameworld:mousemoved(x, y, dx, dy) g3d.camera.firstPersonLook(dx, dy) end
 
 function gameworld:ontilemodified(x, y, z, _)
-  local chunk = self.world:chunk(floor(x / size), floor(y / size), floor(z / size))
+  local spatial = loex.hash.spatial
+  local chunk = self.world:chunk(spatial(floor(x / size), floor(y / size), floor(z / size)))
   assert(chunk)
 
   local tx, ty, tz = x % size, y % size, z % size
   local cx, cy, cz = chunk.x, chunk.y, chunk.z
   local world = self.world
 
-  if tx >= size - 1 then self:requestremesh(world:chunk(cx + 1, cy, cz), true) end
-  if tx <= 0 then self:requestremesh(world:chunk(cx - 1, cy, cz), true) end
-  if ty >= size - 1 then self:requestremesh(world:chunk(cx, cy + 1, cz), true) end
-  if ty <= 0 then self:requestremesh(world:chunk(cx, cy - 1, cz), true) end
-  if tz >= size - 1 then self:requestremesh(world:chunk(cx, cy, cz + 1), true) end
-  if tz <= 0 then self:requestremesh(world:chunk(cx, cy, cz - 1), true) end
+  if tx >= size - 1 then self:requestremesh(world:chunk(spatial(cx + 1, cy, cz)), true) end
+  if tx <= 0 then self:requestremesh(world:chunk(spatial(cx - 1, cy, cz)), true) end
+  if ty >= size - 1 then self:requestremesh(world:chunk(spatial(cx, cy + 1, cz)), true) end
+  if ty <= 0 then self:requestremesh(world:chunk(spatial(cx, cy - 1, cz)), true) end
+  if tz >= size - 1 then self:requestremesh(world:chunk(spatial(cx, cy, cz + 1)), true) end
+  if tz <= 0 then self:requestremesh(world:chunk(spatial(cx, cy, cz - 1)), true) end
 
   self:requestremesh(chunk, true)
 end

--- a/client/scenes/gameworld.lua
+++ b/client/scenes/gameworld.lua
@@ -331,7 +331,7 @@ end
 function gameworld:requestremesh(c, priority)
   -- don't add a nil chunk or a chunk that's already in the queue
   local world = self.world
-  if not c or c.inremesh then return end
+  if not c or c.inremesh or not c.data then return end
 
   c.inremesh = true
   if priority then

--- a/common/brush.lua
+++ b/common/brush.lua
@@ -1,0 +1,115 @@
+local brush = {}
+local insert = table.insert
+local size = loex.chunk.size
+local floor = math.floor
+local spatialhash = loex.hash.spatial
+
+function brush.bounded(world, x, y, z, w, h, d)
+  local new = {}
+  setmetatable(new, { __index = brush })
+  new.world = world
+  new.chunks = {}
+
+  new.minx = x
+  new.miny = y
+  new.minz = z
+  new.maxx = x + w - 1
+  new.maxy = y + h - 1
+  new.maxz = z + d - 1
+  new.ox = x
+  new.oy = y
+  new.oz = z
+  new.w = w
+  new.h = h
+  new.d = d
+  new.dx = x % size
+  new.dy = y % size
+  new.dz = z % size
+  new.cx = floor(x / size)
+  new.cy = floor(y / size)
+  new.cz = floor(z / size)
+  new.cw = floor((x + w - 1) / size) - new.cx + 1
+  new.ch = floor((y + h - 1) / size) - new.cy + 1
+  new.cd = floor((z + d - 1) / size) - new.cz + 1
+
+  for i = new.cx, new.cx + new.cw - 1 do
+    for j = new.cy, new.cy + new.ch - 1 do
+      for k = new.cz, new.cz + new.cd - 1 do
+        local c = world:chunk(spatialhash(i, j, k))
+        assert(c)
+        insert(new.chunks, c)
+      end
+    end
+  end
+  -- new:reset()
+  return new
+end
+
+function brush:reset()
+  self.x = self.ox
+  self.y = self.oy
+  self.z = self.oz
+  self.px = self.x % size
+  self.py = self.y % size
+  self.pz = self.z % size
+  self.cx = floor(self.x / size)
+  self.cy = floor(self.y / size)
+  self.cz = floor(self.z / size)
+  self.i = 1
+  self:refreshc()
+end
+
+function brush:refreshc()
+  local c = self.c
+  c = self.chunks[self.i]
+  c:init()
+  assert(c)
+end
+
+-- function brush:paint(t) self.c.ptr[self.pz * size * size + self.py * size + self.px] = t end
+function brush:paint(x, y, z, t)
+  x, y, z = self.dx + x, self.dy + y, self.dz + z
+  local locx, locy, locz = (x % size), (y % size), (z % size)
+  local c = self.chunks[1 + floor(x / size) * self.ch * self.cd + floor(y / size) * self.cd + floor(z / size)]
+  c:init()
+  c.ptr[locz * size * size + locy * size + locx] = t
+end
+
+function brush:paintonair(x, y, z, t)
+  if self:look(x, y, z) == 0 then return self:paint(x, y, z, t) end
+end
+
+function brush:look(x, y, z)
+  x, y, z = self.dx + x, self.dy + y, self.dz + z
+  local locx, locy, locz = (x % size), (y % size), (z % size)
+  local c = self.chunks[1 + floor(x / size) * self.ch * self.cd + floor(y / size) * self.cd + floor(z / size)]
+  return c:get(locx, locy, locz)
+end
+
+function brush:up()
+  assert(self.z ~= self.maxz)
+  if self.pz == size - 1 then
+    self.pz = 0
+    self.i = self.i + 1
+    self:refreshc()
+  else
+    self.pz = self.pz + 1
+  end
+  self.z = self.z + 1
+end
+
+function brush:down()
+  assert(self.z ~= self.minz)
+  if self.pz == 0 then
+    self.pz = size - 1
+    self.i = self.i - 1
+    self:refreshc()
+  else
+    self.pz = self.pz - 1
+  end
+  self.z = self.z - 1
+end
+
+function brush:move(dx, dy, dz) end
+
+return brush

--- a/common/chunk.lua
+++ b/common/chunk.lua
@@ -41,7 +41,7 @@ function chunk.new(x, y, z)
   return new
 end
 
-function chunk:init() error("Chunk already initialized!") end
+function chunk:init() end
 
 function chunk:set(x, y, z, t)
   if x >= 0 and x < size and y >= 0 and y < size and z >= 0 and z < size then

--- a/common/chunk.lua
+++ b/common/chunk.lua
@@ -67,7 +67,7 @@ function chunk:remove(id)
   return was_before
 end
 
-function chunk:destroy() self.data:release() end
+function chunk:destroy() end
 
 function chunk:dump(uncompressed)
   if not uncompressed then

--- a/common/chunk.lua
+++ b/common/chunk.lua
@@ -36,7 +36,7 @@ function empty_chunk:destroy() end
 function chunk.new(x, y, z)
   local new = {}
   new.x, new.y, new.z = x, y, z
-  new.entities = {}
+  new.hash = loex.hash.spatial(x, y, z)
   new = setmetatable(new, { __index = empty_chunk })
   return new
 end

--- a/common/hash.lua
+++ b/common/hash.lua
@@ -1,0 +1,5 @@
+local hash = {}
+
+function hash.spatial(x, y, z) return table.concat({ x, y, z }, "/") end
+
+return hash

--- a/common/init.lua
+++ b/common/init.lua
@@ -32,6 +32,7 @@ assert(love, "this package needs löve!")
 
 lume = require(loex.lpath .. "lib.lume")
 
+loex.hash = require(loex.lpath .. "hash")
 loex.signal = require(loex.lpath .. "signal")
 loex.utils = require(loex.lpath .. "utils")
 loex.tiles = require(loex.lpath .. "tiles")

--- a/common/init.lua
+++ b/common/init.lua
@@ -39,6 +39,7 @@ loex.tiles = require(loex.lpath .. "tiles")
 loex.chunk = require(loex.lpath .. "chunk")
 loex.entity = require(loex.lpath .. "entity")
 loex.world = require(loex.lpath .. "world")
+loex.brush = require(loex.lpath .. "brush")
 loex.socket = require(loex.lpath .. "socket")
 
 return loex

--- a/common/tiles.lua
+++ b/common/tiles.lua
@@ -7,6 +7,8 @@ tiles.tiles = {
   grass = { id = 3, tex = { 17, 1, 0, 0, 0, 0 } },
   dirt = { id = 4, tex = 1 },
   bricks = { id = 5, tex = 3 },
+  leaves = { id = 6, tex = 16 },
+  log = { id = 7, tex = { 22, 22, 21, 21, 21, 21 } },
 }
 
 local id = {}

--- a/common/world.lua
+++ b/common/world.lua
@@ -2,6 +2,7 @@ local chunk = loex.chunk
 local size = chunk.size
 local floor = math.floor
 local spatialhash = loex.hash.spatial
+local insert = table.insert
 local world = {}
 world.__index = world
 
@@ -39,6 +40,19 @@ function world:remove(e)
   assert(self.entities[id])
   self.entities[id] = nil
   self.onentityremoved:emit(e)
+end
+
+function world:query(...)
+  local res = {}
+  local tags = { ... }
+  for _, e in pairs(self.entities) do
+    local hastags = true
+    for _, tag in ipairs(tags) do
+      hastags = hastags and e:has(tag)
+    end
+    if hastags then insert(res, e) end
+  end
+  return res
 end
 
 function world:entity(id) return self.entities[id] end

--- a/common/world.lua
+++ b/common/world.lua
@@ -1,11 +1,9 @@
 local chunk = loex.chunk
 local size = chunk.size
 local floor = math.floor
-
+local spatialhash = loex.hash.spatial
 local world = {}
 world.__index = world
-
-local function chunkhash(x, y, z) return table.concat({ x, y, z }, "/") end
 
 function world.new()
   local new = {}
@@ -13,9 +11,9 @@ function world.new()
   new.entities = {}
 
   new.ontilemodified = loex.signal.new()
-  new.onentityadded = loex.signal.new()
+  new.onentityinserted = loex.signal.new()
   new.onentityremoved = loex.signal.new()
-  new.onchunkadded = loex.signal.new()
+  new.onchunkinserted = loex.signal.new()
   new.onchunkremoved = loex.signal.new()
 
   setmetatable(new, world)
@@ -23,12 +21,10 @@ function world.new()
   return new
 end
 
-function world:iterate() return pairs(self.entities) end
-
 function world:insert(e)
   assert(not self.entities[e.id])
   self.entities[e.id] = e
-  self.onentityadded:emit(e)
+  self.onentityinserted:emit(e)
 end
 
 function world:remove(e)
@@ -45,21 +41,16 @@ function world:remove(e)
   self.onentityremoved:emit(e)
 end
 
-function world:get(id) return self.entities[id] end
+function world:entity(id) return self.entities[id] end
+function world:chunk(hash) return self.chunks[hash] end
 
-function world:chunk(x, y, z, c)
-  local hash = chunkhash(x, y, z)
-  if c then
-    assert(not self.chunks[hash])
-    self.chunks[hash] = c
-    self.onchunkadded:emit(c)
-  else
-    return self.chunks[hash]
-  end
+function world:insertchunk(c)
+  assert(not self.chunks[c.hash])
+  self.chunks[c.hash] = c
+  self.onchunkinserted:emit(c)
 end
 
-function world:removechunk(x, y, z)
-  local hash = chunkhash(x, y, z)
+function world:removechunk(hash)
   local c = self.chunks[hash]
   assert(c)
   self.chunks[hash] = nil
@@ -68,26 +59,25 @@ function world:removechunk(x, y, z)
 end
 
 function world:tile(x, y, z, t)
+  local c = self:chunk(spatialhash(floor(x / size), floor(y / size), floor(z / size)))
   if t then
-    local chunk = self:chunk(floor(x / size), floor(y / size), floor(z / size))
-    assert(chunk)
+    assert(c)
 
-    local old = chunk:set(x % size, y % size, z % size, t)
+    local old = c:set(x % size, y % size, z % size, t)
     if old ~= t then self.ontilemodified:emit(x, y, z, t) end
   else
-    local chunk = self:chunk(floor(x / size), floor(y / size), floor(z / size))
-    if chunk then return chunk:get(x % size, y % size, z % size) end
+    if c then return c:get(x % size, y % size, z % size) end
     return -1
   end
 end
 
 function world:neighbourhood(x, y, z)
-  return self:chunk(x + 1, y, z),
-    self:chunk(x - 1, y, z),
-    self:chunk(x, y + 1, z),
-    self:chunk(x, y - 1, z),
-    self:chunk(x, y, z + 1),
-    self:chunk(x, y, z - 1)
+  return self:chunk(spatialhash(x + 1, y, z)),
+    self:chunk(spatialhash(x - 1, y, z)),
+    self:chunk(spatialhash(x, y + 1, z)),
+    self:chunk(spatialhash(x, y - 1, z)),
+    self:chunk(spatialhash(x, y, z + 1)),
+    self:chunk(spatialhash(x, y, z - 1))
 end
 
 function world:destroy() end

--- a/server/gen/init.lua
+++ b/server/gen/init.lua
@@ -1,0 +1,8 @@
+local gen = {}
+
+gen.strategy = require("gen.strategy")
+gen.layer = require("gen.layer")
+gen.predicates = require("gen.predicates")
+gen.state = require("gen.state")
+
+return gen

--- a/server/gen/layer.lua
+++ b/server/gen/layer.lua
@@ -1,0 +1,39 @@
+local layer = {}
+local floor, insert = math.floor, table.insert
+local spatialhash = loex.hash.spatial
+
+function layer.new(w, h)
+  local new = {}
+  setmetatable(new, { __index = layer })
+  new.w, new.h = w, h
+  return new
+end
+
+function layer:sample(state, regions, pred)
+  local hunks = state[self]
+
+  local res = {}
+  for r = 1, #regions, 4 do
+    local x = regions[r]
+    local y = regions[r + 1]
+    local w = regions[r + 2]
+    local h = regions[r + 3]
+    for i = floor(x / self.w), floor((x + w - 1) / self.w) do
+      for j = floor(y / self.h), floor((y + h - 1) / self.h) do
+        if not pred or pred(i, j) then
+          local hash = spatialhash(i, j)
+          if not hunks[hash] then
+            hunks[hash] = true
+            insert(res, i * self.w)
+            insert(res, j * self.h)
+            insert(res, self.w)
+            insert(res, self.h)
+          end
+        end
+      end
+    end
+  end
+  return res
+end
+
+return layer

--- a/server/gen/overworld.lua
+++ b/server/gen/overworld.lua
@@ -1,0 +1,257 @@
+local gen = require("gen")
+local chunk = loex.chunk
+local size = chunk.size
+local floor = math.floor
+local tiles = loex.tiles
+local ffi = require("ffi")
+local spatialhash = loex.hash.spatial
+local boundedbrush = loex.brush.bounded
+local concat = lume.concat
+local insert = table.insert
+local distance3d = loex.utils.distance3d
+local max, min = math.max, math.min
+
+local pred = gen.predicates
+local layer_terrain = gen.layer.new(size, size)
+local layer_trees_sampler = gen.layer.new(200, 200)
+local layer_rocks_sampler = gen.layer.new(50, 50)
+local layer_trees = gen.layer.new(5, 5)
+local layer_rocks = gen.layer.new(5, 5)
+local layer_caves = gen.layer.new(100, 100)
+
+local air, dirt, grass, stone, leaves, log =
+  tiles.air.id, tiles.dirt.id, tiles.grass.id, tiles.stone.id, tiles.leaves.id, tiles.log.id
+local noise = love.math.noise
+
+local function debug(layer, t)
+  t = t or stone
+  return function(b)
+    local d = 100
+    for i = 0, layer.w - 1 do
+      b:paint(i, 0, d, stone)
+      b:paint(i, layer.h - 1, d, t)
+    end
+    for j = 0, layer.h - 1 do
+      b:paint(0, j, d, stone)
+      b:paint(layer.w - 1, j, d, t)
+    end
+  end
+end
+
+local overworld = {}
+overworld.columnheight = 10
+-- overworld.strategy = gen.strategy.new {
+--   layers = { layer_trees, layer_terrain, layer_rock },
+--   deps = { [layer_rock] = { layer_terrain }, [layer_trees] = { layer_terrain } },
+-- }
+
+overworld.layers = {
+  layer_trees_sampler,
+  layer_rocks_sampler,
+  layer_terrain,
+  layer_trees,
+  layer_rocks,
+  layer_caves,
+}
+
+local function carvecave(b, rng, ox, oy, oz, startradius, minradius, maxradius)
+  local r = min(max(startradius, minradius), maxradius)
+  local radiusdfactor = 1
+  local dx, dy, dz = ox, oy, oz
+  for _ = 0, 100 do
+    for i = -r, r do
+      for j = -r, r do
+        for k = -r, r do
+          if
+            distance3d(i, j, k, 0, 0, 0, true) <= r * r
+            and not (
+              floor(dx + i) < 0
+              or floor(dx + i) >= b.w
+              or floor(dy + j) < 0
+              or floor(dy + j) >= b.h
+              or floor(dz + k) < 0
+              or floor(dz + k) >= b.d
+            )
+          then
+            b:paint(floor(dx + i), floor(dy + j), floor(dz + k), air)
+          end
+        end
+      end
+    end
+    r = min(max(r + (rng:random() * 2 - 1) * radiusdfactor, minradius), maxradius)
+    dx = dx + (rng:random() * 2 - 1) * 5
+    dy = dy + (rng:random() * 2 - 1) * 5
+    dz = dz - (rng:random()) * 1.6
+  end
+end
+
+overworld.gen = {
+  [layer_terrain] = function(s, b)
+    local hm = love.data.newByteData(ffi.sizeof("int32_t") * size * size)
+    local hmptr = ffi.cast("int32_t *", hm:getFFIPointer())
+    local x, y = b.ox, b.oy
+    local waterlevel = 80
+    local maxlevel = 120
+    local f = 0.5 / 5
+    for i = 0, size - 1 do
+      for j = 0, size - 1 do
+        -- local oc1 = noise((x + i) * f, (y + j) * f)
+        -- local oc2 = 0.5 * noise((x + i + 32313213) * f / 2, (y + j + 21111) * f / 2)
+        -- local oc3 = 0.25 * noise((x + i + 32129843) * f / 4, (y + j - 23121) * f / 4)
+        -- local oc4 = 0.125 * noise((x + i - 2313722) * f / 8, (y + j + 3291083) * f / 8)
+        -- local h = floor((oc1 + oc2 + oc3 + oc4) * 17) + 60
+        -- hmptr[i + j * size] = h
+        -- b:paint(i, j, h, grass)
+        -- for k = 0, h - 1 do
+        --   if h - k > 5 then
+        --   b:paint(i, j, k, stone)
+        --   else
+        --   b:paint(i, j, k, dirt)
+        --   end
+        -- end
+        local d = nil
+        for k = maxlevel, 0, -1 do
+          if noise((x + i) * f, (y + j) * f, k * f) * 21 >= k - waterlevel then
+            if d == nil then d = k end
+            if d - k == 0 then
+              b:paint(i, j, k, grass)
+            elseif d - k <= 5 then
+              b:paint(i, j, k, dirt)
+            else
+              b:paint(i, j, k, stone)
+            end
+          end
+        end
+        hmptr[i + j * size] = d or 0
+      end
+    end
+    s[layer_terrain]:xy(x, y, { data = hm, ptr = hmptr })
+  end,
+  [layer_trees] = function(s, b)
+    local x, y = b.ox + 2, b.oy + 2
+    local hm = s[layer_terrain]:xy(x, y)
+    local d = hm.ptr[x % size + (y % size) * size]
+
+    local len = math.random(3, 8)
+    local root = d + 1
+    local tip = root + len
+
+    if b:look(2, 2, d) ~= grass then return end
+    for i = -2 + 2, 2 + 2 do
+      for j = -2 + 2, 2 + 2 do
+        for k = tip - 2, tip - 1 do
+          b:paintonair(i, j, k, leaves)
+        end
+      end
+    end
+
+    for i = -1 + 2, 1 + 2 do
+      for j = -1 + 2, 1 + 2 do
+        b:paintonair(i, j, tip, leaves)
+      end
+    end
+
+    b:paintonair(2, 2, tip + 1, leaves)
+    b:paintonair(2 + 1, 2, tip + 1, leaves)
+    b:paintonair(2 - 1, 2, tip + 1, leaves)
+    b:paintonair(2, 2 + 1, tip + 1, leaves)
+    b:paintonair(2, 2 - 1, tip + 1, leaves)
+
+    for k = root, tip do
+      b:paint(2, 2, k, log)
+    end
+  end,
+  [layer_rocks] = function(s, b)
+    local x, y = b.ox, b.oy
+    local hm = s[layer_terrain]:xy(x, y)
+    local d = hm.ptr[x % size + (y % size) * size]
+
+    local cx, cy, cz = 2, 2, d
+    local r = 2
+
+    for i = -r, r do
+      for j = -r, r do
+        for k = -r, r do
+          if distance3d(i, j, k, 0, 0, 0, true) <= r * r then
+            b:paint(floor(cx + i), floor(cy + j), floor(cz + k), stone)
+          end
+        end
+      end
+    end
+  end,
+  [layer_caves] = function(s, b)
+    local rng = love.math.newRandomGenerator((b.ox + b.oy))
+    local ox = rng:random(0, b.w - 1)
+    local oy = rng:random(0, b.h - 1)
+
+    local x, y = b.ox + ox, b.oy + oy
+    local hm = s[layer_terrain]:xy(x, y)
+    local oz = hm.ptr[x % size + (y % size) * size]
+
+    carvecave(b, rng, ox, oy, oz, 4, 2, 5)
+  end,
+}
+
+function overworld:initcolumn(w, x, y)
+  for k = 0, self.columnheight - 1 do
+    if not w:chunk(spatialhash(x, y, k)) then w:insertchunk(chunk.new(x, y, k)) end
+  end
+end
+
+function overworld:genlayer(state, layer, hunks)
+  for idx = 1, #hunks, 4 do
+    local x, y = hunks[idx], hunks[idx + 1]
+    local w, h = hunks[idx + 2], hunks[idx + 3]
+
+    for i = floor(x / size), floor((x + w - 1) / size) do
+      for j = floor(y / size), floor((y + h - 1) / size) do
+        self:initcolumn(state.w, i, j)
+      end
+    end
+
+    local brush = boundedbrush(state.w, x, y, 0, w, h, self.columnheight * size)
+    overworld.gen[layer](state, brush)
+  end
+end
+
+function overworld:randsample(state, regions, count, layer)
+  local hunks = state[layer]
+  local res = {}
+  for idx = 1, #regions, 4 do
+    local x, y = regions[idx] / layer.w, regions[idx + 1] / layer.h
+    local w, h = regions[idx + 2] / layer.w, regions[idx + 3] / layer.h
+    local rng = love.math.newRandomGenerator(math.abs(x + y * 32))
+
+    for _ = 1, count do
+      local rx, ry = (x + rng:random(0, w - 1)) * layer.w, (y + rng:random(0, h - 1)) * layer.h
+      local hash = spatialhash(rx / layer.w, ry / layer.h)
+      if not hunks[hash] then
+        hunks[hash] = true
+        insert(res, rx)
+        insert(res, ry)
+        insert(res, layer.w)
+        insert(res, layer.h)
+      end
+    end
+  end
+  return res
+end
+
+function overworld:generate(state, cx, cy, cz)
+  local c = { cx * size, cy * size, size, size }
+  local res = {}
+
+  res[layer_trees] = self:randsample(state, layer_trees_sampler:sample(state, c), 100, layer_trees)
+  res[layer_rocks] = self:randsample(state, layer_rocks_sampler:sample(state, c), 2, layer_rocks)
+  res[layer_caves] = layer_caves:sample(state, c)
+  res[layer_terrain] = layer_terrain:sample(state, concat(c, res[layer_trees], res[layer_rocks], res[layer_caves]))
+
+  self:genlayer(state, layer_terrain, res[layer_terrain])
+  self:genlayer(state, layer_caves, res[layer_caves])
+  self:genlayer(state, layer_trees, res[layer_trees])
+  self:genlayer(state, layer_rocks, res[layer_rocks])
+
+  return state.w:chunk(spatialhash(cx, cy, cz))
+end
+
+return overworld

--- a/server/gen/predicates.lua
+++ b/server/gen/predicates.lua
@@ -1,0 +1,13 @@
+local predicates = {}
+local floor = math.floor
+local random, noise = love.math.random, love.math.noise
+
+function predicates.always(_, _) return true end
+function predicates.never(_, _) return false end
+function predicates.checker(i, j) return (i + j) % 2 == 0 end
+
+function predicates.noise(f, threshold)
+  return function(i, j) return noise(i * f, j * f) > threshold end
+end
+
+return predicates

--- a/server/gen/state.lua
+++ b/server/gen/state.lua
@@ -1,0 +1,30 @@
+local state = {}
+local spatialhash = loex.hash.spatial
+local floor = math.floor
+
+local hunks = {}
+
+function hunks:xy(x, y, hunk)
+  local layer = self.layer
+  local hash = spatialhash(floor(x / layer.w), floor(y / layer.h))
+  if hunk then
+    self[hash] = hunk
+  else
+    return self[hash]
+  end
+end
+
+function state.new(layers, seed)
+  local new = {}
+  new.seed = seed
+  new.rng = love.math.newRandomGenerator(seed)
+  new.w = loex.world.new()
+  for _, layer in ipairs(layers) do
+    local newhunks = { layer = layer }
+    setmetatable(newhunks, { __index = hunks })
+    new[layer] = newhunks
+  end
+  return new
+end
+
+return state

--- a/server/gen/strategy.lua
+++ b/server/gen/strategy.lua
@@ -1,0 +1,37 @@
+local strategy = {}
+
+local function append(a, b)
+  for i = 1, #b do
+    a[#a + 1] = b[i]
+  end
+  return a
+end
+
+function strategy.new(opts)
+  local new = {}
+  new.layers = opts.layers
+  new.deps = opts.deps or {}
+  for _, layer in ipairs(new.layers) do
+    if not new.deps[layer] then new.deps[layer] = {} end
+  end
+  setmetatable(new, { __index = strategy })
+  return new
+end
+
+function strategy:sample(state, x, y, w, h)
+  local res = {}
+
+  for _, layer in ipairs(self.layers) do
+    local segments = layer:sample(state, x, y, w, h)
+    append(res, segments)
+    for _, dep in ipairs(self.deps[layer]) do
+      for _, s in ipairs(segments) do
+        append(res, dep:sample(state, s[2] * layer.w, s[3] * layer.h, layer.w, layer.h))
+      end
+    end
+  end
+
+  return res
+end
+
+return strategy

--- a/server/main.lua
+++ b/server/main.lua
@@ -11,6 +11,7 @@ CHANNEL_UPDATES = 4
 common = require("common")
 packets = require("packets")
 remote = require("remote")
+local player = require("player")
 
 banlist = {}
 takenusernames = {}
@@ -159,18 +160,17 @@ function onreceive(peer, packet)
         peer:disconnect_later()
         return
       end
-      local player = player(0, 0, 50, nil, packet.username, peer)
+      local p = player.entity(0, 0, 180, nil, packet.username, peer)
 
-      peer:send(packets.joinsuccess(player.id, player.x, player.y, player.z), CHANNEL_ONE)
+      peer:send(packets.joinsuccess(p.id, p.x, p.y, p.z), CHANNEL_ONE)
 
-      world:insert(player)
-      peerdata.playerentity = player
+      world:insert(p)
+      peerdata.playerentity = p
 
-      takenusernames[player.username] = true
-
-      print(player.username .. " joined the game :>")
+      takenusernames[p.username] = true
 
       sendworld(peer)
+      print(p.username .. " joined the game :>")
     else
       error("invalid packet for ghost peer")
     end
@@ -201,14 +201,6 @@ function love.update(dt)
 end
 
 function love.quit() socket:disconnect() end
-
-function player(x, y, z, id, username, master)
-  local player = remote(x, y, z, id)
-  player:tag("player")
-  player.username = username
-  player.master = master
-  return player
-end
 
 function verify(username)
   local validUsername = "^[a-zA-Z_]+$"

--- a/server/main.lua
+++ b/server/main.lua
@@ -162,24 +162,16 @@ function love.update(dt)
 
       for _, c in pairs(world.chunks) do
         if not player.inview(e, c.x * size, c.y * size, c.z * size) then
-          if e.view.chunks[c.hash] then
-            e.view:removechunk(c.hash)
-          end
+          if e.view.chunks[c.hash] then e.view:removechunk(c.hash) end
         else
-          if not e.view.chunks[c.hash] then
-            e.view:insertchunk(c)
-          end
+          if not e.view.chunks[c.hash] then e.view:insertchunk(c) end
         end
       end
       for _, entity in pairs(world.entities) do
         if not player.inview(e, entity.x, entity.y, entity.z) then
-          if e.view:entity(entity.id) then
-            e.view:remove(entity)
-          end
+          if e.view:entity(entity.id) then e.view:remove(entity) end
         else
-          if not e.view:entity(entity.id) then
-            e.view:insert(entity)
-          end
+          if not e.view:entity(entity.id) then e.view:insert(entity) end
         end
       end
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -61,13 +61,13 @@ function love.load(args)
   socket.onreceive:catch(onreceive)
 
   world = loex.world.new()
-  world.onentityadded:catch(world_onentityadded)
+  world.onentityinserted:catch(world_onentityinserted)
   world.onentityremoved:catch(world_onentityremoved)
 
   for i = -2, 2 do
     for j = -2, 2 do
       for k = -2, 2 do
-        world:chunk(i, j, k, genchunk(loex.chunk.new(i, j, k)))
+        world:insertchunk(genchunk(loex.chunk.new(i, j, k)))
       end
     end
   end
@@ -78,7 +78,7 @@ function love.load(args)
   -- world:chunk(0, 0, 0, loex.chunk.new(0, 0, 0))
 end
 
-function world_onentityadded(e)
+function world_onentityinserted(e)
   print(e.id .. " added")
   local packet = packets.entityadd(e.id, e.x, e.y, e.z)
   for _, e in pairs(world.entities) do

--- a/server/player.lua
+++ b/server/player.lua
@@ -11,6 +11,14 @@ function player.view_onchunkremoved(e, c)
   e.master:send(packets.chunkremove(c.x, c.y, c.z))
 end
 
+function player.view_onentityinserted(p, e)
+ p.master:send(packets.entityadd(e.id, e.x, e.y, e.z))
+end
+
+function player.view_onentityremoved(p, e)
+ p.master:send(packets.entityremove(e.id))
+end
+
 function player.entity(x, y, z, id, username, master)
   local new = remote(x, y, z, id)
   new:tag("player")
@@ -19,6 +27,8 @@ function player.entity(x, y, z, id, username, master)
   new.view = loex.world.new()
   new.view.onchunkinserted:catch(player.view_onchunkinserted, new)
   new.view.onchunkremoved:catch(player.view_onchunkremoved, new)
+  new.view.onentityinserted:catch(player.view_onentityinserted, new)
+  new.view.onentityremoved:catch(player.view_onentityremoved, new)
   return new
 end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -25,7 +25,7 @@ function player.entity(x, y, z, id, username, master)
 end
 
 function player.inview(e, x, y, z)
-  local range = 2 -- chunks
+  local range = 12 -- chunks
   x, y, z = floor(x / size), floor(y / size), floor(z / size)
   local px, py, pz = floor(e.x / size), floor(e.y / size), floor(e.z / size)
   return loex.utils.distance3d(px, py, 0, x, y, 0, true) <= range * range

--- a/server/player.lua
+++ b/server/player.lua
@@ -3,21 +3,13 @@ local floor = math.floor
 local size = loex.chunk.size
 local remote = require("remote")
 
-function player.view_onchunkinserted(e, c)
-  e.master:send(packets.chunkadd(c:dump(true), c.x, c.y, c.z))
-end
+function player.view_onchunkinserted(e, c) e.master:send(packets.chunkadd(c:dump(true), c.x, c.y, c.z)) end
 
-function player.view_onchunkremoved(e, c)
-  e.master:send(packets.chunkremove(c.x, c.y, c.z))
-end
+function player.view_onchunkremoved(e, c) e.master:send(packets.chunkremove(c.x, c.y, c.z)) end
 
-function player.view_onentityinserted(p, e)
- p.master:send(packets.entityadd(e.id, e.x, e.y, e.z))
-end
+function player.view_onentityinserted(p, e) p.master:send(packets.entityadd(e.id, e.x, e.y, e.z)) end
 
-function player.view_onentityremoved(p, e)
- p.master:send(packets.entityremove(e.id))
-end
+function player.view_onentityremoved(p, e) p.master:send(packets.entityremove(e.id)) end
 
 function player.entity(x, y, z, id, username, master)
   local new = remote(x, y, z, id)

--- a/server/player.lua
+++ b/server/player.lua
@@ -3,12 +3,22 @@ local floor = math.floor
 local size = loex.chunk.size
 local remote = require("remote")
 
+function player.view_onchunkinserted(e, c)
+  e.master:send(packets.chunkadd(c:dump(true), c.x, c.y, c.z))
+end
+
+function player.view_onchunkremoved(e, c)
+  e.master:send(packets.chunkremove(c.x, c.y, c.z))
+end
+
 function player.entity(x, y, z, id, username, master)
   local new = remote(x, y, z, id)
   new:tag("player")
   new.username = username
   new.master = master
   new.view = loex.world.new()
+  new.view.onchunkinserted:catch(player.view_onchunkinserted, new)
+  new.view.onchunkremoved:catch(player.view_onchunkremoved, new)
   return new
 end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -1,0 +1,22 @@
+local player = {}
+local floor = math.floor
+local size = loex.chunk.size
+local remote = require("remote")
+
+function player.entity(x, y, z, id, username, master)
+  local new = remote(x, y, z, id)
+  new:tag("player")
+  new.username = username
+  new.master = master
+  new.view = loex.world.new()
+  return new
+end
+
+function player.inview(e, x, y, z)
+  local range = 2 -- chunks
+  x, y, z = floor(x / size), floor(y / size), floor(z / size)
+  local px, py, pz = floor(e.x / size), floor(e.y / size), floor(e.z / size)
+  return loex.utils.distance3d(px, py, 0, x, y, 0, true) <= range * range
+end
+
+return player


### PR DESCRIPTION
This patch enables infinite and gradual world generation. It introduces a new and extensible worldgen API (still rough on the edges). It also implements locality, such that only entities and chunks inside the player "viewing range" will be sent to that players master client.